### PR TITLE
Added outputs for private and public subnets and bucket name + id

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -24,3 +24,23 @@ output "route53_nameservers" {
   description = "Nameserver for the Route53 zone"
   value       = aws_route53_zone.zone.name_servers
 }
+
+output "private_subnet_ids" {
+  description = "Private subnet IDs from the VPC module"
+  value       = module.vpc.private_subnets
+}
+
+output "public_subnet_ids" {
+  description = "Public subnet IDs from the VPC module"
+  value       = module.vpc.public_subnets
+}
+
+output "bucket_name" {
+  description = "Name of the S3 bucket for Langfuse"
+  value       = aws_s3_bucket.langfuse.bucket
+}
+
+output "bucket_id" {
+  description = "ID of the S3 bucket for Langfuse"
+  value       = aws_s3_bucket.langfuse.id
+}


### PR DESCRIPTION
### TL;DR

Added new output variables to expose VPC subnet IDs and S3 bucket information.

### What changed?

Added four new output variables to the Terraform configuration:
- `private_subnet_ids`: Exposes private subnet IDs from the VPC module
- `public_subnet_ids`: Exposes public subnet IDs from the VPC module
- `bucket_name`: Exposes the name of the S3 bucket for Langfuse
- `bucket_id`: Exposes the ID of the S3 bucket for Langfuse

### How to test?

1. Apply the Terraform configuration
2. Verify the new outputs are available by running `terraform output`
3. Confirm the values match the expected subnet IDs and S3 bucket information

### Why make this change?

These additional outputs make it easier for consumers of this module to reference the VPC subnet IDs and S3 bucket information in their own Terraform configurations without having to use complex references or recreate the same resources.