### PR TITLE
Add configurable EFS throughput mode

### DIFF
--- a/efs.tf
+++ b/efs.tf
@@ -2,7 +2,7 @@
 resource "aws_efs_file_system" "langfuse" {
   creation_token  = "${var.name}-efs"
   encrypted       = true
-  throughput_mode = "elastic"
+  throughput_mode = var.efs_throughput_mode
 
   tags = {
     Name = local.tag_name

--- a/variables.tf
+++ b/variables.tf
@@ -216,3 +216,14 @@ variable "additional_env" {
     error_message = "Each environment variable must have either 'value' or 'valueFrom' specified, but not both."
   }
 }
+
+variable "efs_throughput_mode" {
+  description = "EFS throughput mode. Use 'bursting' for cost savings or 'elastic' for high IO workloads"
+  type        = string
+  default     = "bursting"
+
+  validation {
+    condition     = contains(["bursting", "elastic", "provisioned"], var.efs_throughput_mode)
+    error_message = "efs_throughput_mode must be one of: bursting, elastic, provisioned"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `efs_throughput_mode` variable to configure EFS throughput mode
- Change default from `elastic` to `bursting` to reduce costs
- Elastic mode was charging $0.06/GB for writes, costing ~$550/month with ClickHouse's write-heavy workload

## Test plan
- [x] Manually switched EFS to bursting mode via AWS CLI
- [ ] Apply terraform with new module version

🤖 Generated with [Claude Code](https://claude.com/claude-code)